### PR TITLE
Addons from RP for DelphesO2

### DIFF
--- a/DetectorK.cxx
+++ b/DetectorK.cxx
@@ -27,6 +27,7 @@ Bool_t DetectorK::verboseR=0;
 
 #define RIDICULOUS 999999 // A ridiculously large resolution (cm) to flag a dead detector
 
+#define xrhosteps     10          // steps for dEdx correction
 #define Luminosity    1.e27       // Luminosity of the beam (LHC HI == 1.e27, RHIC II == 8.e27 )
 #define SigmaD        6.0         // Size of the interaction diamond (cm) (LHC = 6.0 cm)
 #define dNdEtaMinB    1//950//660//950           // Multiplicity per unit Eta  (AuAu MinBias = 170, Central = 700)
@@ -915,8 +916,8 @@ void DetectorK::SolveViaBilloir(Double_t selPt, double ptmin) {
 
       if (lr->xrho>0) { // correct in small steps
 	bool elossOK = kTRUE;
-	for (int ise=10;ise--;) {
-	  if (!probTrLast.CorrectForMeanMaterial(0, -lr->xrho/10, fParticleMass , kTRUE)) {elossOK = kFALSE; break;}
+	for (int ise=xrhosteps;ise--;) {
+	  if (!probTrLast.CorrectForMeanMaterial(0, -lr->xrho/xrhosteps, fParticleMass , kTRUE)) {elossOK = kFALSE; break;}
 	}
 	if (!elossOK) break;
       }
@@ -1033,8 +1034,8 @@ void DetectorK::SolveViaBilloir(Double_t selPt, double ptmin) {
 	exit(1);
       }
       if (layer->xrho>0) { // correct in small steps
-	for (int ise=10;ise--;) {
-	  if (!probTr.CorrectForMeanMaterial(0, layer->xrho/10, fParticleMass , kTRUE)) {
+	for (int ise=xrhosteps;ise--;) {
+	  if (!probTr.CorrectForMeanMaterial(0, layer->xrho/xrhosteps, fParticleMass , kTRUE)) {
 	    printf("Failed to apply material correction, xrho=%.4f\n",layer->xrho);
 	    probTr.Print();
 	    exit(1);
@@ -1246,8 +1247,8 @@ void DetectorK::SolveViaBilloir(Double_t selPt, double ptmin) {
 	  exit(1);
 	}
 	if (layer->xrho>0) { // correct in small steps
-	  for (int ise=10;ise--;) {
-	    if (!probTr.CorrectForMeanMaterial(0, -layer->xrho/10, fParticleMass , kTRUE)) {
+	  for (int ise=xrhosteps;ise--;) {
+	    if (!probTr.CorrectForMeanMaterial(0, -layer->xrho/xrhosteps, fParticleMass , kTRUE)) {
 	      printf("Failed to apply material correction, xrho=%.4f\n",-layer->xrho);
 	      probTr.Print();
 	      exit(1);
@@ -1503,8 +1504,8 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
     bool ok = PropagateToR(&probTrLast,lr->radius,bGauss,1);
     if (ok) ok = probTrLast.CorrectForMeanMaterial(lr->radL, 0, mass , kTRUE);
     if (ok && lr->xrho>0) {
-      for (int ise=10;ise--;) {
-	ok = probTrLast.CorrectForMeanMaterial(0, -lr->xrho/10, mass , kTRUE);
+      for (int ise=xrhosteps;ise--;) {
+	ok = probTrLast.CorrectForMeanMaterial(0, -lr->xrho/xrhosteps, mass , kTRUE);
 	if (!ok) break;
       }
     }
@@ -1590,8 +1591,8 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
       exit(1);
     }
     if (layer->xrho>0) { // correct in small steps
-      for (int ise=10;ise--;) {
-	if (!probTr.CorrectForMeanMaterial(0, layer->xrho/10, mass , kTRUE)) {
+      for (int ise=xrhosteps;ise--;) {
+	if (!probTr.CorrectForMeanMaterial(0, layer->xrho/xrhosteps, mass , kTRUE)) {
 	  printf("Failed to apply material correction, xrho=%.4f\n",layer->xrho);
 	  probTr.Print();
 	  exit(1);
@@ -1687,8 +1688,8 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
       exit(1);
     }
     if (layer->xrho>0) { // correct in small steps
-      for (int ise=10;ise--;) {
-	if (!probTr.CorrectForMeanMaterial(0, -layer->xrho/10, mass , kTRUE)) {
+      for (int ise=xrhosteps;ise--;) {
+	if (!probTr.CorrectForMeanMaterial(0, -layer->xrho/xrhosteps, mass , kTRUE)) {
 	  printf("Failed to apply material correction, xrho=%.4f\n",-layer->xrho);
 	  probTr.Print();
 	  exit(1);

--- a/DetectorK.cxx
+++ b/DetectorK.cxx
@@ -1560,7 +1560,7 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
 	printf("Failed to rotate to the frame (phi:%+.3f)of layer at %.2f at XYZ: %+.3f %+.3f %+.3f (pt=%+.3f)\n",
 	       phi,layer->radius,pos[0],pos[1],pos[2],pt);	
 	probTr.Print();
-	exit(1);
+	return kFALSE; // exit(1);
       }
     }
     // save inward parameters at this layer: before the update!
@@ -1580,7 +1580,7 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
 	printf("Failed to update the track by measurement {%.3f,%3f} err {%.3e %.3e %.3e}\n",
 	       meas[0],meas[1], measErr2[0],measErr2[1],measErr2[2]);
 	probTr.Print();
-	exit(1);
+	return kFALSE; // exit(1);
       }
     }
     // correct for materials of this layer
@@ -1588,14 +1588,14 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
     if (layer->radL>0 && !probTr.CorrectForMeanMaterial(layer->radL, 0, mass , kTRUE)) {
       printf("Failed to apply material correction, X/X0=%.4f\n",layer->radL);
       probTr.Print();
-      exit(1);
+      return kFALSE; // exit(1);
     }
     if (layer->xrho>0) { // correct in small steps
       for (int ise=xrhosteps;ise--;) {
 	if (!probTr.CorrectForMeanMaterial(0, layer->xrho/xrhosteps, mass , kTRUE)) {
 	  printf("Failed to apply material correction, xrho=%.4f\n",layer->xrho);
 	  probTr.Print();
-	  exit(1);
+	  return kFALSE; // exit(1);
 	}
       }
     }
@@ -1653,7 +1653,7 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
 	printf("Failed to rotate to the frame (phi:%+.3f)of layer at %.2f at XYZ: %+.3f %+.3f %+.3f (pt=%+.3f)\n",
 	       phi,layer->radius,pos[0],pos[1],pos[2],pt);	      
 	probTr.Print();
-	exit(1);
+	return kFALSE; // exit(1);
       }
     }
     //
@@ -1678,21 +1678,21 @@ Bool_t DetectorK::SolveTrack(TrackSol& ts) {
 	printf("Failed to update the track by measurement {%.3f,%3f} err {%.3e %.3e %.3e}\n",
 	       meas[0],meas[1], measErr2[0],measErr2[1],measErr2[2]);
 	probTr.Print();
-	exit(1);
+	return kFALSE; // exit(1);
       }
     }
     // note: if apart from MS we want also e.loss correction, the density*length should be provided as 2nd param
     if (layer->radL>0 && !probTr.CorrectForMeanMaterial(layer->radL, 0, mass , kTRUE)) {
       printf("Failed to apply material correction, X/X0=%.4f\n",layer->radL);
       probTr.Print();
-      exit(1);
+      return kFALSE; // exit(1);
     }
     if (layer->xrho>0) { // correct in small steps
       for (int ise=xrhosteps;ise--;) {
 	if (!probTr.CorrectForMeanMaterial(0, -layer->xrho/xrhosteps, mass , kTRUE)) {
 	  printf("Failed to apply material correction, xrho=%.4f\n",-layer->xrho);
 	  probTr.Print();
-	  exit(1);
+	  return kFALSE; // exit(1);
 	}
       }
     }

--- a/DetectorK.h
+++ b/DetectorK.h
@@ -230,6 +230,8 @@ class DetectorK : public TNamed {
 
   Bool_t IsITSLayer(const TString& lname);
 
+  Double_t GetGoodHitProb(Int_t i) { return fGoodHitProb[i]; };
+  
   static Bool_t verboseR;
  protected:
  
@@ -266,7 +268,8 @@ class DetectorK : public TNamed {
   Double_t fDetPointZRes[kMaxNumberOfDetectors][kNptBins];   // array of z resolution per layer
   Double_t fEfficiency[kNptBins];                            // efficiency 
   Double_t fFake[kNptBins];                                  // fake prob
-
+  Double_t fGoodHitProb[kMaxNumberOfDetectors];              // array of good hit probability per layer
+  
   Int_t kDetLayer;                              // layer for which a few more details are extracted
   Double_t fResolutionRPhiLay[kNptBins];                        // array of rphi resolution
   Double_t fResolutionZLay[kNptBins];                           // array of z resolution


### PR DESCRIPTION
hi @shahor02 
a few more updates from your side, hoping they are acceptable for you

1. define xrhostep commit add a `#define` with the number of steps to be done for the dEdx correction, such that it can be globally applied in case a different number is needed
2. in `SolveTrack` there are multiple instances where in case of a failure the program `exit(1)`. this creates some problem in the way I used it while looping over multiple tracks. So I prefer to `return kFALSE`, take care of the local failure and be able to continue with the next track in the same program
3. wanted to calculate and bring outside for each layer the probability of good hit (see TOF mismatch) as well as to accumulate the numbers to bring out the probability of "all good hits" in the tracker
